### PR TITLE
Add REST API to service from qgisserver

### DIFF
--- a/giscube/urls.py
+++ b/giscube/urls.py
@@ -56,6 +56,8 @@ if not settings.GISCUBE_GIS_SERVER_DISABLED:
     ]
     router.register(r'qgisserver/project', qgisserver_api.ProjectViewSet,
                     base_name='qgisserver_project')
+    router.register(r'qgisserver/service', qgisserver_api.ServiceViewSet,
+                    base_name='qgisserver_service')
 
 if not settings.GISCUBE_GEOPORTAL_DISABLED:
     urlpatterns += [

--- a/qgisserver/api.py
+++ b/qgisserver/api.py
@@ -9,7 +9,7 @@ from rest_framework.pagination import PageNumberPagination
 from rest_framework.response import Response
 
 from .models import Project, Service
-from .serializers import ProjectSerializer
+from .serializers import ProjectSerializer, ServiceSerializer
 
 
 class StandardResultsSetPagination(PageNumberPagination):
@@ -51,3 +51,10 @@ class ProjectViewSet(viewsets.ModelViewSet):
         data = serializer.data
 
         return Response(data)
+
+
+class ServiceViewSet(viewsets.ModelViewSet):
+    lookup_field = 'name'
+    queryset = Project.objects.all().order_by('pk')
+    serializer_class = ServiceSerializer
+    pagination_class = StandardResultsSetPagination

--- a/qgisserver/api.py
+++ b/qgisserver/api.py
@@ -55,6 +55,6 @@ class ProjectViewSet(viewsets.ModelViewSet):
 
 class ServiceViewSet(viewsets.ModelViewSet):
     lookup_field = 'name'
-    queryset = Project.objects.all().order_by('pk')
+    queryset = Service.objects.all().order_by('pk')
     serializer_class = ServiceSerializer
     pagination_class = StandardResultsSetPagination

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -21,3 +21,15 @@ class APITestCase(BaseTest):
         url = reverse('qgisserver_project-list')
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
+
+
+    def test_api_qgisserver_service_list_unathenticated(self):
+        url = reverse('qgisserver_service-list')
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 401)
+
+    def test_api_qgisserver_service_list(self):
+        self.login_test_user()
+        url = reverse('qgisserver_service-list')
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
New URLs:
 - `/api/v1/qgisserver/service/` (list and create)
 - `/api/v1/qgisserver/service/<name>/` (edit and delete)