### PR TITLE
Add tests database to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ giscube/static/
 /env/
 /.project
 /.coverage
+test.db


### PR DESCRIPTION
Add `test.db` into the .gitignore.
Rebased to `/hotfix/migrations/` for merging simplicity.